### PR TITLE
Set the DraCor Server in an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ You can also directly configure Claude to use the DraCor MCP server by adding th
 
 Replace `/path/to/dracor-mcp/` with the actual path to your dracor-mcp directory. This configuration uses `uv run` to execute the MCP server with the necessary dependencies without requiring a prior installation.
 
+If you want to use a different server, e.g. the staging server, add it to the configuration file after the arguments:
+
+```
+"env": {
+  "DRACOR_API_BASE_URL": "https://staging.dracor.org/api/v1" 
+  }
+```
+
 ### Docker (optional)
 
 If you prefer using Docker:

--- a/dracor_mcp_fastmcp.py
+++ b/dracor_mcp_fastmcp.py
@@ -3,9 +3,11 @@
 from typing import Dict, List, Optional, Any, Union
 import requests
 from mcp.server.fastmcp import FastMCP
+import os
 
 # Base API URL for DraCor v1
-DRACOR_API_BASE_URL = "https://dracor.org/api/v1"
+# Set the Base URL in the environment variable DRACOR_API_BASE_URL 
+DRACOR_API_BASE_URL = str(os.environ.get("DRACOR_API_BASE_URL", "https://dracor.org/api/v1"))
 
 # Create the FastMCP server instance
 mcp = FastMCP("DraCor API v1")


### PR DESCRIPTION
Allows for setting the DraCor Server to use with the environment variable `DRACOR_API_BASE_URL`. Default is the production server, so this should not break anything, but in the Claude Desktop Configuration adding an env object 
```
"env": {
        "DRACOR_API_BASE_URL": "https://staging.dracor.org/api/v1"
      }
``` after the arguments allows to change the server.